### PR TITLE
Updates subscription to fix pipeline runs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,11 @@ locals {
     olmNamespace = var.olm_namespace
     operatorNamespace = var.operator_namespace
     app = "tekton"
+    ocpCatalog = {
+      source = "community-operators"
+      channel = "dev-preview"
+      name = "openshift-pipelines-operator"
+    }
   }
   tool_config = {
     url = "https://${local.ingress_host}"


### PR DESCRIPTION
- Reverts the subscription configuration to use the openshift-pipelines-operator from the community-operators catalog

Fixes ibm-garage-cloud/planning#450