### PR TITLE
Skips wait-for-webhook when deploying on ocp 4.6

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -17,7 +17,9 @@ jobs:
 
     strategy:
       matrix:
-        platform: [ocp4_latest]
+        platform:
+          - ocp4_latest
+          - ocp46
       #      max-parallel: 1
       fail-fast: false
 

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,7 @@ locals {
     url = local.ingress_url
     applicationMenu = false
   }
+  ocp46 = length(regexall("4[.]6.*", data.local_file.cluster_version.content)) > 0
 }
 
 resource "null_resource" "setup_dirs" {
@@ -148,7 +149,7 @@ resource "null_resource" "wait-for-crd" {
 
 resource "null_resource" "wait-for-webhook" {
   depends_on = [null_resource.wait-for-crd]
-  count = var.mode != "setup" && var.cluster_type == "ocp4" ? 1 : 0
+  count = var.mode != "setup" && var.cluster_type == "ocp4" && !local.ocp46 ? 1 : 0
 
   provisioner "local-exec" {
     command = "${path.module}/scripts/wait-for-webhook.sh '${var.tools_namespace}'"

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,6 @@ locals {
     url = local.ingress_url
     applicationMenu = false
   }
-  ocp46 = length(regexall("4[.]6.*", data.local_file.cluster_version.content)) > 0
 }
 
 resource "null_resource" "setup_dirs" {
@@ -149,10 +148,10 @@ resource "null_resource" "wait-for-crd" {
 
 resource "null_resource" "wait-for-webhook" {
   depends_on = [null_resource.wait-for-crd]
-  count = var.mode != "setup" && var.cluster_type == "ocp4" && !local.ocp46 ? 1 : 0
+  count = var.mode != "setup" && var.cluster_type == "ocp4" ? 1 : 0
 
   provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-webhook.sh '${var.tools_namespace}'"
+    command = "${path.module}/scripts/wait-for-webhook.sh '${var.tools_namespace}' '${data.local_file.cluster_version.content}'"
 
     environment = {
       KUBECONFIG = var.cluster_config_file_path

--- a/scripts/wait-for-webhook.sh
+++ b/scripts/wait-for-webhook.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
 NAMESPACE="$1"
+VERSION="$2"
+
+if [[ "${VERSION}" =~ 4[.]6 ]]; then
+  echo "Cluster is 4.6 version of Openshift. No need to wait for webhook."
+  exit 0
+fi
 
 if [[ -z "${TMP_DIR}" ]]; then
   TMP_DIR=".tmp"


### PR DESCRIPTION
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>