### PR TITLE
Select subscription channel by cluster version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ locals {
   chart_name          = "tekton"
   chart_dir           = "${path.module}/chart/${local.chart_name}"
   created_by          = "tekton-${random_string.random.result}"
+  pipeline_channel    = local.cluster_version == "4.8" ? "stable" : "latest"
   global_config       = {
     enabled = var.provision
     clusterType = local.cluster_type
@@ -21,7 +22,7 @@ locals {
     createdBy = local.created_by
     app = "tekton"
     ocpCatalog = {
-      channel = "stable"
+      channel = local.pipeline_channel
     }
   }
   tool_config = {


### PR DESCRIPTION
fixes #47 

This logic will not work well for clusters at 4.7 and earlier. But these clusters are not supported at the present time.